### PR TITLE
hideCardScanner option added to Android configuration.

### DIFF
--- a/android/src/main/java/com/paymentsdk/flutter_paymentsdk_bridge/FlutterPaytabsBridgePlugin.java
+++ b/android/src/main/java/com/paymentsdk/flutter_paymentsdk_bridge/FlutterPaytabsBridgePlugin.java
@@ -399,6 +399,7 @@ public class FlutterPaytabsBridgePlugin implements FlutterPlugin, MethodCallHand
                 .setMerchantIcon(iconUri)
                 .setScreenTitle(screenTitle)
                 .linkBillingNameWithCard(paymentDetails.optBoolean("pt_link_billing_name"))
+                .hideCardScanner(paymentDetails.optBoolean("pt_hide_card_scanner"))
                 .build();
     }
 


### PR DESCRIPTION
Tap on Card Scanner crash fix.