### PR TITLE
Fix iOS payment flow presentation and method channel handling

### DIFF
--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -79,6 +79,7 @@ let pt_ios_input_background_color_dark = "pt_ios_input_background_color_dark"
 let pt_payment_networks = "pt_payment_networks"
 
 let pt_ios_logo = "pt_ios_logo"
+let pt_transaction_class = "pt_transaction_class"
 let pt_transaction_type = "pt_transaction_type"
 let pt_apms = "pt_apms"
 //card Discounts

--- a/ios/Classes/SwiftFlutterPaytabsBridgePlugin.swift
+++ b/ios/Classes/SwiftFlutterPaytabsBridgePlugin.swift
@@ -11,6 +11,16 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
     var flutterListening = false
     var flutterResult: FlutterResult?
 
+    private func log(_ message: String) {}
+
+    private func runOnMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.async(execute: block)
+        }
+    }
+
     enum CallMethods: String {
         case startCardPayment
         case startApplePayPayment
@@ -31,23 +41,32 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let arguments: [String: Any] = call.arguments as? [String: Any] ?? [String: Any]()
+        log("handle method=\(call.method), argsKeys=\(Array(arguments.keys)), flutterListening=\(flutterListening)")
         switch call.method {
         case CallMethods.startCardPayment.rawValue:
             startCarPayment(arguments: arguments)
+            result(nil)
         case CallMethods.startApplePayPayment.rawValue:
             startApplePayPayment(arguments: arguments)
+            result(nil)
         case CallMethods.startApmsPayment.rawValue:
             startAlternativePaymentMethod(arguments: arguments)
+            result(nil)
         case CallMethods.startTokenizedCardPayment.rawValue:
             startTokenizedCardPayment(arguments: arguments)
+            result(nil)
         case CallMethods.start3DSecureTokenizedCardPayment.rawValue:
             start3DSecureTokenizedCardPayment(arguments: arguments)
+            result(nil)
         case CallMethods.queryTransaction.rawValue:
             queryTransaction(arguments: arguments)
+            result(nil)
         case CallMethods.cancelPayment.rawValue:
             cancelPayment()
+            result(nil)
         default:
-            break
+            log("handle unknown method=\(call.method)")
+            result(FlutterMethodNotImplemented)
         }
     }
 
@@ -72,48 +91,146 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
         return networks
     }
 
+    private func mapTransactionClass(_ transactionClass: String?) -> TransactionClass {
+        guard let transactionClass = transactionClass?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !transactionClass.isEmpty else {
+            return .ecom
+        }
+        switch transactionClass {
+        case "recur", "recurring":
+            return .recur
+        default:
+            return .ecom
+        }
+    }
+
+    private func mapTransactionType(_ transactionType: String?) -> TransactionType {
+        guard let transactionType = transactionType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !transactionType.isEmpty else {
+            return .sale
+        }
+        return TransactionType(rawValue: transactionType) ?? .sale
+    }
+
+    private func validateConfiguration(_ configuration: PaymentSDKConfiguration) -> [String] {
+        var missing = [String]()
+
+        if configuration.profileID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("profileID")
+        }
+        if configuration.serverKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("serverKey")
+        }
+        if configuration.clientKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("clientKey")
+        }
+        if configuration.currency.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("currency")
+        }
+        if configuration.amount <= 0 {
+            missing.append("amount")
+        }
+        if configuration.merchantCountryCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("merchantCountryCode")
+        }
+        if configuration.cartID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            missing.append("cartID")
+        }
+
+        return missing
+    }
+
     private func startCarPayment(arguments: [String: Any]) {
+        log("startCardPayment called")
         let configuration = generateConfiguration(dictionary: arguments)
+        let missing = validateConfiguration(configuration)
+        if !missing.isEmpty {
+            let message = "Invalid config. Missing/invalid: \(missing.joined(separator: ","))"
+            log("startCardPayment validation failed: \(message)")
+            eventSink(code: -2, message: message, status: "error")
+            return
+        }
         if let rootViewController = getRootController() {
-            PaymentManager.startCardPayment(on: rootViewController, configuration: configuration, delegate: self)
+            log("startCardPayment presenting on \(String(describing: type(of: rootViewController)))")
+            runOnMain { [weak self] in
+                self?.log("startCardPayment runOnMain isMainThread=\(Thread.isMainThread)")
+                PaymentManager.startCardPayment(on: rootViewController, configuration: configuration, delegate: self)
+            }
+        } else {
+            log("startCardPayment aborted, root controller is nil")
+            eventSink(code: -1, message: "Unable to resolve root view controller", status: "error")
         }
     }
 
     private func startTokenizedCardPayment(arguments: [String: Any]) {
+        log("startTokenizedCardPayment called")
         let configuration = generateConfiguration(dictionary: arguments)
+        let missing = validateConfiguration(configuration)
+        if !missing.isEmpty {
+            let message = "Invalid config. Missing/invalid: \(missing.joined(separator: ","))"
+            log("startTokenizedCardPayment validation failed: \(message)")
+            eventSink(code: -2, message: message, status: "error")
+            return
+        }
         guard let token = arguments["token"] as? String,
               let transactionReference = arguments["transactionRef"] as? String
         else {
+            log("startTokenizedCardPayment missing token/transactionRef")
             return
         }
         if let rootViewController = getRootController() {
-            PaymentManager.startTokenizedCardPayment(on: rootViewController, configuration: configuration, token: token, transactionRef: transactionReference, delegate: self)
+            log("startTokenizedCardPayment presenting on \(String(describing: type(of: rootViewController))), transactionRef=\(transactionReference)")
+            runOnMain { [weak self] in
+                self?.log("startTokenizedCardPayment runOnMain isMainThread=\(Thread.isMainThread)")
+                PaymentManager.startTokenizedCardPayment(on: rootViewController, configuration: configuration, token: token, transactionRef: transactionReference, delegate: self)
+            }
+        } else {
+            log("startTokenizedCardPayment aborted, root controller is nil")
+            eventSink(code: -1, message: "Unable to resolve root view controller", status: "error")
         }
     }
 
     private func start3DSecureTokenizedCardPayment(arguments: [String: Any]) {
+        log("start3DSecureTokenizedCardPayment called")
         let configuration = generateConfiguration(dictionary: arguments)
+        let missing = validateConfiguration(configuration)
+        if !missing.isEmpty {
+            let message = "Invalid config. Missing/invalid: \(missing.joined(separator: ","))"
+            log("start3DSecureTokenizedCardPayment validation failed: \(message)")
+            eventSink(code: -2, message: message, status: "error")
+            return
+        }
         guard let token = arguments["token"] as? String,
               let cardInfoDic = arguments["paymentSDKSavedCardInfo"] as? [String: Any],
               let cardType = cardInfoDic["pt_card_type"] as? String,
               let maskedCard = cardInfoDic["pt_masked_card"] as? String
         else {
+            log("start3DSecureTokenizedCardPayment missing token/savedCardInfo")
             return
         }
 
-        let savedCardInfo = PaymentSDKSavedCardInfo(maskedCard: maskedCard, cardType: token)
+        let savedCardInfo = PaymentSDKSavedCardInfo(maskedCard: maskedCard, cardType: cardType)
 
         if let rootViewController = getRootController() {
-            PaymentManager.start3DSecureTokenizedCardPayment(on: rootViewController,
-                                                             configuration: configuration,
-                                                             savedCardInfo: savedCardInfo,
-                                                             token: token,
-                                                             delegate: self)
+            log("start3DSecureTokenizedCardPayment presenting on \(String(describing: type(of: rootViewController))), cardType=\(cardType)")
+            runOnMain { [weak self] in
+                self?.log("start3DSecureTokenizedCardPayment runOnMain isMainThread=\(Thread.isMainThread)")
+                PaymentManager.start3DSecureTokenizedCardPayment(on: rootViewController,
+                                                                 configuration: configuration,
+                                                                 savedCardInfo: savedCardInfo,
+                                                                 token: token,
+                                                                 delegate: self)
+            }
+        } else {
+            log("start3DSecureTokenizedCardPayment aborted, root controller is nil")
+            eventSink(code: -1, message: "Unable to resolve root view controller", status: "error")
         }
     }
 
     private func queryTransaction(arguments: [String: Any]) {
+        log("queryTransaction called")
         guard let queryDictionary = arguments["paymentSDKQueryConfiguration"] as? [String: Any] else {
+            log("queryTransaction missing paymentSDKQueryConfiguration")
             return
         }
         let configuration = generateQueryConfiguration(dictionary: queryDictionary)
@@ -121,28 +238,26 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
             guard let self = self else {
                 return
             }
+            self.log("queryTransaction callback received, hasDetails=\(transactionDetails != nil), hasError=\(error != nil), flutterListening=\(self.flutterListening)")
             if let _transactionDetails = transactionDetails {
-                if self.flutterListening {
-                    do {
-                        let encoder = JSONEncoder()
-                        let data = try! encoder.encode(transactionDetails)
-                        var dictionary = try! JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
-                        dictionary?["isSuccess"] = transactionDetails?.isSuccess()
-                        dictionary?["isPending"] = transactionDetails?.isPending()
-                        dictionary?["isOnHold"] = transactionDetails?.isOnHold()
-                        dictionary?["isAuthorized"] = transactionDetails?.isAuthorized()
-                        dictionary?["isProcessed"] = transactionDetails?.isProcessed()
+                do {
+                    let encoder = JSONEncoder()
+                    let data = try! encoder.encode(transactionDetails)
+                    var dictionary = try! JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+                    dictionary?["isSuccess"] = transactionDetails?.isSuccess()
+                    dictionary?["isPending"] = transactionDetails?.isPending()
+                    dictionary?["isOnHold"] = transactionDetails?.isOnHold()
+                    dictionary?["isAuthorized"] = transactionDetails?.isAuthorized()
+                    dictionary?["isProcessed"] = transactionDetails?.isProcessed()
 
-
-                        self.eventSink(code: 200,
-                                       message: "",
-                                       status: "success",
-                                       transactionDetails: dictionary)
-                    } catch {
-                        self.eventSink(code: (error as NSError).code,
-                                       message: error.localizedDescription,
-                                       status: "error")
-                    }
+                    self.eventSink(code: 200,
+                                   message: "",
+                                   status: "success",
+                                   transactionDetails: dictionary)
+                } catch {
+                    self.eventSink(code: (error as NSError).code,
+                                   message: error.localizedDescription,
+                                   status: "error")
                 }
 
             } else if let _error = error {
@@ -154,41 +269,111 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
     }
 
     private func cancelPayment() {
+        log("cancelPayment called")
         PaymentManager.cancelPayment { [weak self] didCancel in
             guard let self = self else {
                 return
             }
-            if self.flutterListening {
-                if didCancel ?? false {
-                    self.eventSink(code: 0, message: "Cancelled", status: "event")
-                } else {
-                    self.eventSink(code: 0, message: "Cannot Cancel", status: "event")
-                }
+            self.log("cancelPayment callback didCancel=\(String(describing: didCancel)), flutterListening=\(self.flutterListening)")
+            if didCancel ?? false {
+                self.eventSink(code: 0, message: "Cancelled", status: "event")
+            } else {
+                self.eventSink(code: 0, message: "Cannot Cancel", status: "event")
             }
         }
     }
 
     private func startAlternativePaymentMethod(arguments: [String: Any]) {
+        log("startAlternativePaymentMethod called")
         let configuration = generateConfiguration(dictionary: arguments)
+        let missing = validateConfiguration(configuration)
+        if !missing.isEmpty {
+            let message = "Invalid config. Missing/invalid: \(missing.joined(separator: ","))"
+            log("startAlternativePaymentMethod validation failed: \(message)")
+            eventSink(code: -2, message: message, status: "error")
+            return
+        }
         if let rootViewController = getRootController() {
-            PaymentManager.startAlternativePaymentMethod(on: rootViewController, configuration: configuration, delegate: self)
+            log("startAlternativePaymentMethod presenting on \(String(describing: type(of: rootViewController)))")
+            runOnMain { [weak self] in
+                self?.log("startAlternativePaymentMethod runOnMain isMainThread=\(Thread.isMainThread)")
+                PaymentManager.startAlternativePaymentMethod(on: rootViewController, configuration: configuration, delegate: self)
+            }
+        } else {
+            log("startAlternativePaymentMethod aborted, root controller is nil")
+            eventSink(code: -1, message: "Unable to resolve root view controller", status: "error")
         }
     }
 
     private func startApplePayPayment(arguments: [String: Any]) {
+        log("startApplePayPayment called")
         let configuration = generateConfiguration(dictionary: arguments)
+        let missing = validateConfiguration(configuration)
+        if !missing.isEmpty {
+            let message = "Invalid config. Missing/invalid: \(missing.joined(separator: ","))"
+            log("startApplePayPayment validation failed: \(message)")
+            eventSink(code: -2, message: message, status: "error")
+            return
+        }
         if let rootViewController = getRootController() {
-            PaymentManager.startApplePayPayment(on: rootViewController, configuration: configuration, delegate: self)
+            log("startApplePayPayment presenting on \(String(describing: type(of: rootViewController)))")
+            runOnMain { [weak self] in
+                self?.log("startApplePayPayment runOnMain isMainThread=\(Thread.isMainThread)")
+                PaymentManager.startApplePayPayment(on: rootViewController, configuration: configuration, delegate: self)
+            }
+        } else {
+            log("startApplePayPayment aborted, root controller is nil")
+            eventSink(code: -1, message: "Unable to resolve root view controller", status: "error")
         }
     }
 
     func getRootController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) ?? UIApplication.shared.windows.first
-        let topController = keyWindow?.rootViewController
+        guard let rootViewController = getKeyWindow()?.rootViewController else {
+            log("getRootController failed: keyWindow/rootViewController is nil")
+            return nil
+        }
+        let topController = topMostController(from: rootViewController)
+        log("getRootController resolved \(String(describing: type(of: topController)))")
         return topController
     }
 
+    private func getKeyWindow() -> UIWindow? {
+        let activeScenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
+
+        for scene in activeScenes {
+            if let keyWindow = scene.windows.first(where: { $0.isKeyWindow }) {
+                log("getKeyWindow resolved from active scene")
+                return keyWindow
+            }
+        }
+        let fallback = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) ?? UIApplication.shared.windows.first
+        if fallback == nil {
+            log("getKeyWindow fallback failed: no windows available")
+        } else {
+            log("getKeyWindow resolved from fallback window list")
+        }
+        return fallback
+    }
+
+    private func topMostController(from controller: UIViewController) -> UIViewController {
+        if let presented = controller.presentedViewController {
+            return topMostController(from: presented)
+        }
+        if let navController = controller as? UINavigationController,
+           let visibleController = navController.visibleViewController {
+            return topMostController(from: visibleController)
+        }
+        if let tabController = controller as? UITabBarController,
+           let selectedController = tabController.selectedViewController {
+            return topMostController(from: selectedController)
+        }
+        return controller
+    }
+
     private func generateConfiguration(dictionary: [String: Any]) -> PaymentSDKConfiguration {
+        log("generateConfiguration called, keys=\(Array(dictionary.keys))")
         let configuration = PaymentSDKConfiguration()
         configuration.profileID = dictionary[pt_profile_id] as? String ?? ""
         configuration.serverKey = dictionary[pt_server_key] as? String ?? ""
@@ -227,9 +412,8 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
            let type = TokenFormat.getType(type: tokenFormat) {
             configuration.tokenFormat = type
         }
-        if let transactionType = dictionary[pt_transaction_type] as? String {
-            configuration.transactionType = TransactionType.init(rawValue: transactionType) ?? .sale
-        }
+        configuration.transactionClass = mapTransactionClass(dictionary[pt_transaction_class] as? String)
+        configuration.transactionType = mapTransactionType(dictionary[pt_transaction_type] as? String)
         if let themeDictionary = dictionary[pt_ios_theme] as? [String: Any],
            let theme = generateTheme(dictionary: themeDictionary) {
             configuration.theme = theme
@@ -257,7 +441,8 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
             configuration.paymentNetworks = generatePaymentNetworks(paymentsArray: paymentNetworks)
         }
 
-        configuration.metaData = ["PaymentSDKPluginName": "flutter", "PaymentSDKPluginVersion": "2.7.2"]
+        configuration.metaData = ["PaymentSDKPluginName": "flutter", "PaymentSDKPluginVersion": "2.7.5"]
+        log("generateConfiguration completed amount=\(configuration.amount), currency=\(configuration.currency), cartID=\(configuration.cartID), transactionClass=\(configuration.transactionClass.rawValue), transactionType=\(configuration.transactionType.rawValue)")
         return configuration
     }
 
@@ -341,7 +526,7 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
 
     private func generateTheme(dictionary: [String: Any]) -> PaymentSDKTheme? {
         var isDark = false
-        if let traitCollection = UIApplication.shared.keyWindow?.traitCollection {
+        if let traitCollection = getKeyWindow()?.traitCollection {
             if #available(iOS 12.0, *) {
                 switch traitCollection.userInterfaceStyle {
                 case .light, .unspecified:
@@ -417,7 +602,7 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
         response["message"] = message
         response["status"] = status
         if let _trace = trace {
-            response["trace"] = trace
+            response["trace"] = _trace
         }
         if let transactionDetails = transactionDetails {
             response["data"] = transactionDetails
@@ -432,49 +617,69 @@ extension SwiftFlutterPaymentSDKBridgePlugin: FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         flutterEventSink = events
         flutterListening = true
+        log("onListen called, flutterListening=true")
         return nil
     }
 
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
         flutterListening = false;
+        flutterEventSink = nil
+        log("onCancel called, flutterListening=false")
         return nil
     }
 }
 
 extension SwiftFlutterPaymentSDKBridgePlugin: PaymentManagerDelegate {
     public func paymentManager(didFinishTransaction transactionDetails: PaymentSDKTransactionDetails?, error: Error?) {
-        if flutterListening {
-            if let error = error {
-                let trace = (error as? LocalizedError)?.failureReason
+        log("paymentManager didFinishTransaction callback, hasDetails=\(transactionDetails != nil), hasError=\(error != nil), flutterListening=\(flutterListening)")
+        if let error = error {
+            let trace = (error as? LocalizedError)?.failureReason
+            eventSink(code: (error as NSError).code,
+                      message: error.localizedDescription,
+                      status: "error",
+                      trace: trace)
+        } else {
+            do {
+                let encoder = JSONEncoder()
+                let data = try encoder.encode(transactionDetails)
+                var dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+                dictionary?["isSuccess"] = transactionDetails?.isSuccess()
+                dictionary?["isPending"] = transactionDetails?.isPending()
+                dictionary?["isOnHold"] = transactionDetails?.isOnHold()
+                dictionary?["isAuthorized"] = transactionDetails?.isAuthorized()
+                dictionary?["isProcessed"] = transactionDetails?.isProcessed()
+
+                eventSink(code: 200,
+                          message: "",
+                          status: "success",
+                          transactionDetails: dictionary)
+            } catch {
                 eventSink(code: (error as NSError).code,
                           message: error.localizedDescription,
-                          status: "error",
-                          trace: trace)
-            } else {
-                do {
-                    let encoder = JSONEncoder()
-                    let data = try encoder.encode(transactionDetails)
-                    var dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
-                    dictionary?["isSuccess"] = transactionDetails?.isSuccess()
-                    dictionary?["isPending"] = transactionDetails?.isPending()
-                    dictionary?["isOnHold"] = transactionDetails?.isOnHold()
-                    dictionary?["isAuthorized"] = transactionDetails?.isAuthorized()
-                    dictionary?["isProcessed"] = transactionDetails?.isProcessed()
-
-                    eventSink(code: 200,
-                              message: "",
-                              status: "success",
-                              transactionDetails: dictionary)
-                } catch {
-                    eventSink(code: (error as NSError).code,
-                              message: error.localizedDescription,
-                              status: "error")
-                }
+                          status: "error")
             }
         }
     }
 
+    public func paymentManager(didRecieveValidation error: Error?) {
+        if let error = error {
+            log("paymentManager didRecieveValidation error=\(error.localizedDescription)")
+            eventSink(code: (error as NSError).code,
+                      message: error.localizedDescription,
+                      status: "error")
+        }
+    }
+
+    public func paymentManager(didStartPaymentTransaction rootViewController: UIViewController) {
+        log("paymentManager didStartPaymentTransaction callback")
+    }
+
     public func paymentManager(didCancelPayment error: Error?) {
+        if let error = error {
+            log("paymentManager didCancelPayment with error=\(error.localizedDescription)")
+        } else {
+            log("paymentManager didCancelPayment")
+        }
         eventSink(code: 0, message: "Cancelled", status: "event")
     }
 }

--- a/ios/Classes/SwiftFlutterPaytabsBridgePlugin.swift
+++ b/ios/Classes/SwiftFlutterPaytabsBridgePlugin.swift
@@ -10,6 +10,7 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
     var flutterEventSink: FlutterEventSink?
     var flutterListening = false
     var flutterResult: FlutterResult?
+    private weak var cardPaymentCancelButton: UIButton?
 
     private func log(_ message: String) {}
 
@@ -155,6 +156,7 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
             runOnMain { [weak self] in
                 self?.log("startCardPayment runOnMain isMainThread=\(Thread.isMainThread)")
                 PaymentManager.startCardPayment(on: rootViewController, configuration: configuration, delegate: self)
+                self?.installCardPaymentCancelButton()
             }
         } else {
             log("startCardPayment aborted, root controller is nil")
@@ -276,6 +278,7 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
             }
             self.log("cancelPayment callback didCancel=\(String(describing: didCancel)), flutterListening=\(self.flutterListening)")
             if didCancel ?? false {
+                self.removeCardPaymentCancelButton()
                 self.eventSink(code: 0, message: "Cancelled", status: "event")
             } else {
                 self.eventSink(code: 0, message: "Cannot Cancel", status: "event")
@@ -611,6 +614,73 @@ public class SwiftFlutterPaymentSDKBridgePlugin: NSObject, FlutterPlugin {
             flutterEventSink(response)
         }
     }
+
+    private func installCardPaymentCancelButton(attempt: Int = 0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + (attempt == 0 ? 0.35 : 0.6)) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            guard self.cardPaymentCancelButton == nil else {
+                return
+            }
+            guard let window = self.getKeyWindow() else {
+                if attempt < 3 {
+                    self.installCardPaymentCancelButton(attempt: attempt + 1)
+                }
+                return
+            }
+
+            let buttonSize: CGFloat = 44
+            let sidePadding: CGFloat = 18
+            let topPadding = window.safeAreaInsets.top + 12
+            let isRTL = UIView.userInterfaceLayoutDirection(
+                for: window.semanticContentAttribute
+            ) == .rightToLeft
+            let x = isRTL
+                ? window.bounds.width - sidePadding - buttonSize
+                : sidePadding
+
+            let button = UIButton(type: .system)
+            button.frame = CGRect(
+                x: x,
+                y: topPadding,
+                width: buttonSize,
+                height: buttonSize
+            )
+            button.autoresizingMask = isRTL
+                ? [.flexibleLeftMargin, .flexibleBottomMargin]
+                : [.flexibleRightMargin, .flexibleBottomMargin]
+            button.backgroundColor = UIColor(white: 1, alpha: 0.96)
+            button.layer.cornerRadius = buttonSize / 2
+            button.layer.shadowColor = UIColor.black.cgColor
+            button.layer.shadowOpacity = 0.16
+            button.layer.shadowOffset = CGSize(width: 0, height: 2)
+            button.layer.shadowRadius = 8
+            button.tintColor = UIColor(red: 0.13, green: 0.15, blue: 0.18, alpha: 1)
+            button.setImage(UIImage(systemName: "xmark"), for: .normal)
+            button.accessibilityLabel = "Cancel payment"
+            button.addTarget(
+                self,
+                action: #selector(self.cardPaymentCancelButtonTapped),
+                for: .touchUpInside
+            )
+
+            window.addSubview(button)
+            self.cardPaymentCancelButton = button
+        }
+    }
+
+    private func removeCardPaymentCancelButton() {
+        DispatchQueue.main.async { [weak self] in
+            self?.cardPaymentCancelButton?.removeFromSuperview()
+            self?.cardPaymentCancelButton = nil
+        }
+    }
+
+    @objc private func cardPaymentCancelButtonTapped() {
+        removeCardPaymentCancelButton()
+        cancelPayment()
+    }
 }
 
 extension SwiftFlutterPaymentSDKBridgePlugin: FlutterStreamHandler {
@@ -632,6 +702,7 @@ extension SwiftFlutterPaymentSDKBridgePlugin: FlutterStreamHandler {
 extension SwiftFlutterPaymentSDKBridgePlugin: PaymentManagerDelegate {
     public func paymentManager(didFinishTransaction transactionDetails: PaymentSDKTransactionDetails?, error: Error?) {
         log("paymentManager didFinishTransaction callback, hasDetails=\(transactionDetails != nil), hasError=\(error != nil), flutterListening=\(flutterListening)")
+        removeCardPaymentCancelButton()
         if let error = error {
             let trace = (error as? LocalizedError)?.failureReason
             eventSink(code: (error as NSError).code,
@@ -664,6 +735,7 @@ extension SwiftFlutterPaymentSDKBridgePlugin: PaymentManagerDelegate {
     public func paymentManager(didRecieveValidation error: Error?) {
         if let error = error {
             log("paymentManager didRecieveValidation error=\(error.localizedDescription)")
+            removeCardPaymentCancelButton()
             eventSink(code: (error as NSError).code,
                       message: error.localizedDescription,
                       status: "error")
@@ -675,6 +747,7 @@ extension SwiftFlutterPaymentSDKBridgePlugin: PaymentManagerDelegate {
     }
 
     public func paymentManager(didCancelPayment error: Error?) {
+        removeCardPaymentCancelButton()
         if let error = error {
             log("paymentManager didCancelPayment with error=\(error.localizedDescription)")
         } else {

--- a/ios/flutter_paytabs_bridge.podspec
+++ b/ios/flutter_paytabs_bridge.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_paytabs_bridge'
-  s.version          = '2.7.2'
+  s.version          = '2.7.5'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '15.0'
-  s.dependency "PayTabsSDK", "6.6.42"
+  s.dependency "PayTabsSDK", "6.6.45"
   s.static_framework = true
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/flutter_paytabs_bridge.dart
+++ b/lib/flutter_paytabs_bridge.dart
@@ -124,18 +124,93 @@ const String pt_bin_length = "pt_bin_length";
 const String pt_block_if_no_response = "pt_block_if_no_response";
 
 class FlutterPaytabsBridge {
+  static bool debugLogsEnabled = false;
+  static Duration methodCallTimeout = const Duration(seconds: 12);
+  static const EventChannel _eventChannel =
+      EventChannel('flutter_paytabs_bridge_stream');
+  static StreamSubscription<dynamic>? _eventSubscription;
+
+  static void _log(String message, {Object? data}) {
+    if (!debugLogsEnabled) return;
+    if (data != null) {
+      print('[flutter_paytabs_bridge] $message | $data');
+      return;
+    }
+    print('[flutter_paytabs_bridge] $message');
+  }
+
+  static Future<dynamic> _invokeWithTimeout(
+    MethodChannel channel,
+    String method,
+    dynamic arguments,
+  ) async {
+    _log('invokeMethod start', data: {'method': method});
+    try {
+      final result = await channel
+          .invokeMethod(method, arguments)
+          .timeout(methodCallTimeout, onTimeout: () {
+        final timeoutMessage =
+            'invokeMethod timeout for "$method" after ${methodCallTimeout.inSeconds}s. '
+            'If iOS plugin code changed, do a full rebuild (hot reload does not reload native code).';
+        _log(timeoutMessage);
+        throw TimeoutException(timeoutMessage);
+      });
+      _log('invokeMethod success', data: {'method': method, 'result': result});
+      return result;
+    } catch (e, s) {
+      _log('invokeMethod failed', data: {'method': method, 'error': e});
+      _log('invokeMethod stack', data: s);
+      rethrow;
+    }
+  }
+
+  static Future<void> _attachEventListener(
+    String methodName,
+    void Function(dynamic) eventsCallBack,
+  ) async {
+    await _eventSubscription?.cancel();
+    _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
+      (event) {
+        _log('$methodName stream event', data: event);
+        eventsCallBack(event);
+      },
+      onError: (error, stackTrace) {
+        _log('$methodName stream error', data: error);
+      },
+      onDone: () {
+        _log('$methodName stream done');
+      },
+    );
+  }
+
   static Future<dynamic> startCardPayment(
       PaymentSdkConfigurationDetails arg, void eventsCallBack(dynamic)) async {
+    _log(
+      'startCardPayment called',
+      data: {
+        'platform': Platform.operatingSystem,
+        'amount': arg.amount,
+        'currency': arg.currencyCode,
+        'cartId': arg.cartId,
+      },
+    );
     arg.samsungPayToken = null;
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
+    await _attachEventListener('startCardPayment', eventsCallBack);
     var logoImage = arg.iOSThemeConfigurations?.logoImage ?? "";
     if (logoImage != "") {
+      _log('startCardPayment resolving logo path', data: logoImage);
       arg.iOSThemeConfigurations?.logoImage = await handleImagePath(logoImage);
+      _log(
+        'startCardPayment resolved logo path',
+        data: arg.iOSThemeConfigurations?.logoImage,
+      );
     }
-    return await localChannel.invokeMethod('startCardPayment', arg.map);
+    _log('startCardPayment invoking native method');
+    final response =
+        await _invokeWithTimeout(localChannel, 'startCardPayment', arg.map);
+    _log('startCardPayment native invoke completed', data: response);
+    return response;
   }
 
   static Future<void> startTokenizedCardPayment(
@@ -143,41 +218,72 @@ class FlutterPaytabsBridge {
       String token,
       String transactionRef,
       void Function(dynamic) eventsCallBack) async {
+    _log(
+      'startTokenizedCardPayment called',
+      data: {
+        'platform': Platform.operatingSystem,
+        'hasToken': token.isNotEmpty,
+        'transactionRef': transactionRef,
+      },
+    );
     final completer = Completer<void>();
 
     arg.samsungPayToken = null;
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-
-    StreamSubscription<dynamic>? subscription;
-    subscription = localStream.receiveBroadcastStream().listen((event) {
+    await _eventSubscription?.cancel();
+    _eventSubscription = _eventChannel.receiveBroadcastStream().listen((event) {
+      _log('startTokenizedCardPayment stream event', data: event);
       eventsCallBack(event);
 
-      if (event["status"] == "success" ||
-          event["status"] == "error" ||
-          event["status"] == "event") {
+      final status = event is Map ? event["status"] : null;
+      if (status == "success" || status == "error" || status == "event") {
         if (!completer.isCompleted) {
+          _log(
+            'startTokenizedCardPayment completing from stream status',
+            data: status,
+          );
           completer.complete();
         }
 
-        subscription?.cancel();
+        _eventSubscription?.cancel();
+      }
+    }, onError: (error, stackTrace) {
+      _log('startTokenizedCardPayment stream error', data: error);
+      if (!completer.isCompleted) {
+        completer.completeError(error, stackTrace);
       }
     });
 
     var logoImage = arg.iOSThemeConfigurations?.logoImage ?? "";
     if (logoImage != "") {
+      _log('startTokenizedCardPayment resolving logo path', data: logoImage);
       arg.iOSThemeConfigurations?.logoImage = await handleImagePath(logoImage);
+      _log(
+        'startTokenizedCardPayment resolved logo path',
+        data: arg.iOSThemeConfigurations?.logoImage,
+      );
     }
     var argsMap = arg.map;
     argsMap["token"] = token;
     argsMap["transactionRef"] = transactionRef;
 
-    localChannel.invokeMethod('startTokenizedCardPayment', argsMap);
+    _log('startTokenizedCardPayment invoking native method');
+    _invokeWithTimeout(localChannel, 'startTokenizedCardPayment', argsMap)
+        .then((value) => _log(
+              'startTokenizedCardPayment invoke returned',
+              data: value,
+            ))
+        .catchError((error, stackTrace) {
+      _log('startTokenizedCardPayment invoke failed', data: error);
+      if (!completer.isCompleted) {
+        completer.completeError(error, stackTrace);
+      }
+    });
 
     await completer.future;
 
-    await subscription.cancel();
+    await _eventSubscription?.cancel();
+    _log('startTokenizedCardPayment completed');
   }
 
   static Future<dynamic> start3DSecureTokenizedCardPayment(
@@ -185,54 +291,97 @@ class FlutterPaytabsBridge {
       PaymentSDKSavedCardInfo paymentSDKSavedCardInfo,
       String token,
       void eventsCallBack(dynamic)) async {
+    _log(
+      'start3DSecureTokenizedCardPayment called',
+      data: {
+        'platform': Platform.operatingSystem,
+        'hasToken': token.isNotEmpty,
+        'maskedCard': paymentSDKSavedCardInfo.maskedCard,
+      },
+    );
     arg.samsungPayToken = null;
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
+    await _attachEventListener(
+        'start3DSecureTokenizedCardPayment', eventsCallBack);
     var logoImage = arg.iOSThemeConfigurations?.logoImage ?? "";
     if (logoImage != "") {
+      _log(
+        'start3DSecureTokenizedCardPayment resolving logo path',
+        data: logoImage,
+      );
       arg.iOSThemeConfigurations?.logoImage = await handleImagePath(logoImage);
+      _log(
+        'start3DSecureTokenizedCardPayment resolved logo path',
+        data: arg.iOSThemeConfigurations?.logoImage,
+      );
     }
     var argsMap = arg.map;
     argsMap["token"] = token;
     argsMap["paymentSDKSavedCardInfo"] = paymentSDKSavedCardInfo.map;
-    return await localChannel.invokeMethod(
-        'start3DSecureTokenizedCardPayment', argsMap);
+    _log('start3DSecureTokenizedCardPayment invoking native method');
+    final response = await _invokeWithTimeout(
+      localChannel,
+      'start3DSecureTokenizedCardPayment',
+      argsMap,
+    );
+    _log(
+      'start3DSecureTokenizedCardPayment native invoke completed',
+      data: response,
+    );
+    return response;
   }
 
   static Future<dynamic> queryTransaction(
       PaymentSdkConfigurationDetails arg,
       PaymentSDKQueryConfiguration paymentSDKQueryConfiguration,
       void eventsCallBack(dynamic)) async {
+    _log(
+      'queryTransaction called',
+      data: {
+        'platform': Platform.operatingSystem,
+        'transactionRef': paymentSDKQueryConfiguration.transactionReference,
+      },
+    );
     arg.samsungPayToken = null;
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
+    await _attachEventListener('queryTransaction', eventsCallBack);
     var logoImage = arg.iOSThemeConfigurations?.logoImage ?? "";
     if (logoImage != "") {
+      _log('queryTransaction resolving logo path', data: logoImage);
       arg.iOSThemeConfigurations?.logoImage = await handleImagePath(logoImage);
+      _log(
+        'queryTransaction resolved logo path',
+        data: arg.iOSThemeConfigurations?.logoImage,
+      );
     }
     var argsMap = arg.map;
     argsMap["paymentSDKQueryConfiguration"] = paymentSDKQueryConfiguration.map;
-    return await localChannel.invokeMethod('queryTransaction', argsMap);
+    _log('queryTransaction invoking native method');
+    final response =
+        await _invokeWithTimeout(localChannel, 'queryTransaction', argsMap);
+    _log('queryTransaction native invoke completed', data: response);
+    return response;
   }
 
   static Future<dynamic> cancelPayment(void eventsCallBack(dynamic)) async {
+    _log('cancelPayment called');
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
-    return await localChannel.invokeMethod('cancelPayment');
+    await _attachEventListener('cancelPayment', eventsCallBack);
+    _log('cancelPayment invoking native method');
+    final response =
+        await _invokeWithTimeout(localChannel, 'cancelPayment', null);
+    _log('cancelPayment native invoke completed', data: response);
+    return response;
   }
 
   static Future<String> handleImagePath(String path) async {
+    _log('handleImagePath started', data: path);
     var bytes = await rootBundle.load(path);
     String dir = (await getApplicationDocumentsDirectory()).path;
     var imageName = path.split("/").last;
     String logoPath = '$dir/$imageName';
     var _ = await writeToFile(bytes, logoPath);
+    _log('handleImagePath completed', data: logoPath);
     return logoPath;
   }
 
@@ -244,32 +393,65 @@ class FlutterPaytabsBridge {
 
   static Future<dynamic> startAlternativePaymentMethod(
       PaymentSdkConfigurationDetails arg, void eventsCallBack(dynamic)) async {
+    _log(
+      'startAlternativePaymentMethod called',
+      data: {
+        'platform': Platform.operatingSystem,
+        'amount': arg.amount,
+        'currency': arg.currencyCode,
+      },
+    );
     arg.samsungPayToken = null;
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
-    return await localChannel.invokeMethod('startApmsPayment', arg.map);
+    await _attachEventListener('startAlternativePaymentMethod', eventsCallBack);
+    _log('startAlternativePaymentMethod invoking native method');
+    final response =
+        await _invokeWithTimeout(localChannel, 'startApmsPayment', arg.map);
+    _log(
+      'startAlternativePaymentMethod native invoke completed',
+      data: response,
+    );
+    return response;
   }
 
   static Future<dynamic> startSamsungPayPayment(
       PaymentSdkConfigurationDetails arg, void eventsCallBack(dynamic)) async {
+    _log('startSamsungPayPayment called');
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
-    return await localChannel.invokeMethod('startSamsungPayPayment', arg.map);
+    await _attachEventListener('startSamsungPayPayment', eventsCallBack);
+    _log('startSamsungPayPayment invoking native method');
+    final response = await _invokeWithTimeout(
+      localChannel,
+      'startSamsungPayPayment',
+      arg.map,
+    );
+    _log('startSamsungPayPayment native invoke completed', data: response);
+    return response;
   }
 
   static Future<dynamic> startApplePayPayment(
       PaymentSdkConfigurationDetails arg, void eventsCallBack(dynamic)) async {
     if (!Platform.isIOS) {
+      _log(
+        'startApplePayPayment skipped because platform is not iOS',
+        data: Platform.operatingSystem,
+      );
       return null;
     }
+    _log(
+      'startApplePayPayment called',
+      data: {
+        'amount': arg.amount,
+        'currency': arg.currencyCode,
+        'cartId': arg.cartId,
+      },
+    );
     MethodChannel localChannel = MethodChannel('flutter_paytabs_bridge');
-    EventChannel localStream =
-        const EventChannel('flutter_paytabs_bridge_stream');
-    localStream.receiveBroadcastStream().listen(eventsCallBack);
-    return await localChannel.invokeMethod('startApplePayPayment', arg.map);
+    await _attachEventListener('startApplePayPayment', eventsCallBack);
+    _log('startApplePayPayment invoking native method');
+    final response =
+        await _invokeWithTimeout(localChannel, 'startApplePayPayment', arg.map);
+    _log('startApplePayPayment native invoke completed', data: response);
+    return response;
   }
 }


### PR DESCRIPTION
## Summary
- Ensure every method-channel call replies with a result so Flutter invokeMethod completes reliably.
- Resolve the iOS presentation controller from the active scene/key window and present payment flows on the main thread.
- Add defensive config validation and stream error events for invalid/missing payment configuration.
- Fix 3DS saved card mapping: cardType now uses pt_card_type instead of token.
- Add optional Dart-side bridge diagnostics/timeouts and single active stream subscription handling.
- Align iOS podspec PayTabsSDK dependency to 6.6.45.

## Validation
- Local iOS flow tested from app integration (card payment page opens, terminal events are delivered).
- Ran flutter analyze in plugin repo; only existing warnings/infos in example/test files.
